### PR TITLE
ci: add generate-mcp-server job to release pipeline

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -6,6 +6,7 @@ orbs:
   orb-tools: circleci/orb-tools@12.4.0
   # The orb definition is intentionally not included here. It will be injected into the pipeline.
   zola-orb: {}
+  toolkit: jerus-org/circleci-toolkit@6.1.0
 
 # Use this tag to ensure test jobs always run,
 # even though the downstream publish job will only run on release tags.
@@ -38,6 +39,23 @@ workflows:
 
       # The orb must be re-packed for publishing, and saved to the workspace.
       - orb-tools/pack:
+          filters: *release-filters
+
+      # Generate MCP server binary and attach to the GitHub release.
+      - toolkit/build_mcp_server:
+          name: generate-mcp-server
+          orb_name: zola-orb
+          binary_name: zola_orb_mcp
+          version: << pipeline.git.tag >>
+          release_tag: << pipeline.git.tag >>
+          prime_history: true
+          prime_earliest_version: "1.0.0"
+          context:
+            - bot-check
+            - release
+            - pcu_app
+          requires:
+            - command-test
           filters: *release-filters
 
       - orb-tools/publish:


### PR DESCRIPTION
## Summary

- Imports `jerus-org/circleci-toolkit@6.1.0` into `test-deploy.yml`
- Adds a `toolkit/build_mcp_server` job (`generate-mcp-server`) to the release workflow
- On each version tag, the job primes history from all versions since `1.0.0`, generates the MCP server source, compiles the binary, and uploads `zola_orb_mcp` as a release asset

## Dependencies

This PR depends on digital-prstv/circleci-toolkit#TBD (strip `v` prefix in `build_mcp_server`) being released before this workflow fires correctly. The toolkit reference will be bumped to that version (via Renovate or manually) before the next zola-orb release.

## Test plan

- [ ] PR CI passes (command-test, lint-pack)
- [ ] On next release tag, `generate-mcp-server` job completes and `zola_orb_mcp` binary appears as a release asset

🤖 Generated with [Claude Code](https://claude.com/claude-code)