### PR TITLE
ci: migrate MCP build to gen-orb-mcp orb

### DIFF
--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -11,7 +11,7 @@ parameters:
     description: "Override workspace v* version (empty = nextsv auto-detect)"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.6.1
+  toolkit: jerus-org/circleci-toolkit@6.6.2
 
 workflows:
   release:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -6,7 +6,7 @@ orbs:
   orb-tools: circleci/orb-tools@12.4.0
   # The orb definition is intentionally not included here. It will be injected into the pipeline.
   zola-orb: {}
-  toolkit: jerus-org/circleci-toolkit@6.6.1
+  gen-orb-mcp: jerus-org/gen-orb-mcp@0.2.0
 
 # Use this tag to ensure test jobs always run,
 # even though the downstream publish job will only run on release tags.
@@ -42,14 +42,12 @@ workflows:
           filters: *release-filters
 
       # Generate MCP server binary and attach to the GitHub release.
-      - toolkit/build_mcp_server:
+      - gen-orb-mcp/build_mcp_server:
           name: generate-mcp-server
-          orb_name: zola-orb
           binary_name: zola_orb_mcp
-          version: << pipeline.git.tag >>
-          release_tag: << pipeline.git.tag >>
-          prime_history: true
-          prime_earliest_version: "1.0.0"
+          tag_prefix: v
+          orb_path: src/@orb.yml
+          earliest_version: "1.0.0"
           context:
             - bot-check
             - release

--- a/.circleci/update_prlog.yml
+++ b/.circleci/update_prlog.yml
@@ -15,7 +15,7 @@ parameters:
     description: "If true, pcu is updated from its main github branch before running."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.6.1
+  toolkit: jerus-org/circleci-toolkit@6.6.2
 
 workflows:
   update_prlog:


### PR DESCRIPTION
## What & why

Now that **gen-orb-mcp publishes its own orb** (`jerus-org/gen-orb-mcp`), zola-orb's release pipeline should build its MCP server via that dedicated orb rather than the `toolkit/build_mcp_server` job. This matches the already-migrated reference (gen-circleci-orb uses `gen-orb-mcp/build_mcp_server`).

## Changes

**`test-deploy.yml` — migrate the MCP build:**
- `toolkit/build_mcp_server` → `gen-orb-mcp/build_mcp_server`
- Orb declaration `toolkit@6.6.1` → `gen-orb-mcp@0.2.0` (build_mcp_server was the only `toolkit/` usage in this file)
- Parameter remap to the new job's schema:

| old (`toolkit`) | new (`gen-orb-mcp`) |
|---|---|
| `orb_name: zola-orb` | *(dropped — derived from orb source)* |
| `version: << pipeline.git.tag >>` | `tag_prefix: v` (VERSION extracted from the `v*` release tag) |
| `release_tag: << pipeline.git.tag >>` | *(dropped — derived from tag_prefix)* |
| `prime_history: true` | *(always primes)* |
| `prime_earliest_version: "1.0.0"` | `earliest_version: "1.0.0"` |
| — | `orb_path: src/@orb.yml` (zola-orb's orb source) |

`binary_name`, `context`, `requires`, and `filters` are unchanged.

**`release.yml` + `update_prlog.yml` — bring toolkit current:** `circleci-toolkit@6.6.1` → `@6.6.2` (latest, 2026-07-19). zola-orb had no Renovate PR in flight for this, so main was a patch behind.

## Notes

- `tag_prefix: v` matches zola-orb's release filter `/^v[0-9]+\.[0-9]+\.[0-9]+$/`; `orb_path: src/@orb.yml` matches the repo layout (verified).
- Follow-up (not in this PR): the toolkit still ships `build_mcp_server`/`generate_mcp_server`/`prime_mcp_history` and dogfoods them in its own `test-deploy.yml`. With zola-orb migrated, no external consumer remains — those can be deprecated from the toolkit in a dedicated release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
